### PR TITLE
Update for new SDK Call object model

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,5 +4,5 @@ source 'https://github.com/CocoaPods/Specs.git'
 target 'SwiftVoiceQuickstart' do
   use_frameworks!
 
-  pod 'TwilioVoiceClient', '=2.0.0-beta5'
+  pod 'TwilioVoiceClient', '=2.0.0-beta6'
 end

--- a/SwiftVoiceQuickstart/Info.plist
+++ b/SwiftVoiceQuickstart/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>$(EXECUTABLE_NAME) would like to access your microphone</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
@@ -22,6 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>$(EXECUTABLE_NAME) would like to access your microphone</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -155,6 +155,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         
         if (self.callInvite != nil && self.callInvite?.state == .pending) {
             NSLog("Already a pending call invite. Ignoring incoming call invite from \(callInvite.from)")
+            return
         } else if (self.call != nil && self.call?.state == .connected) {
             NSLog("Already an active call. Ignoring incoming call invite from \(callInvite.from)");
             return;

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -176,6 +176,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             if let strongSelf = self {
                 strongSelf.stopIncomingRingtone(completion: {_ in
                     callInvite.reject()
+                    strongSelf.callInvite = nil
                 })
                 strongSelf.incomingAlertController = nil
                 strongSelf.toggleUIState(isEnabled: true)
@@ -187,6 +188,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             if let strongSelf = self {
                 /* To ignore the call invite, you don't have to do anything but just literally ignore it */
                 
+                strongSelf.callInvite = nil
                 strongSelf.stopIncomingRingtone(completion: nil)
                 strongSelf.incomingAlertController = nil
                 strongSelf.toggleUIState(isEnabled: true)
@@ -198,6 +200,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             if let strongSelf = self {
                 strongSelf.stopIncomingRingtone(completion: {_ in
                     callInvite.accept(with: strongSelf)
+                    strongSelf.callInvite = nil
                 })
 
                 strongSelf.incomingAlertController = nil


### PR DESCRIPTION
The latest Voice SDK has consolidated the `TVOIncomingCall` & `TVOOutgoingCall` objects into an unified `TVOCall` object. A new `TVOCallInvite` object is also introduced to abstract the incoming attributes from the original `TVOIncomingCall` object.

Also added some sample code to demonstrate how to use the `TVOCall.disconnect` method to hang up the call properly.