### PR TITLE
For Voice 2.0.0-beta12

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'SwiftVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '=2.0.0-beta11'
+  pod 'TwilioVoice', '=2.0.0-beta12'
   use_frameworks!
 
   target 'SwiftVoiceQuickstart' do

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -173,8 +173,8 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         reportIncomingCall(from: "Voice Bot", uuid: callInvite.uuid)
     }
     
-    func callInviteCancelled(_ callInvite: TVOCallInvite?) {
-        NSLog("callInviteCancelled:")
+    func callInviteCanceled(_ callInvite: TVOCallInvite?) {
+        NSLog("callInviteCanceled:")
         
         if let callInvite = callInvite {
             performEndCallAction(uuid: callInvite.uuid)

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -221,11 +221,11 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         }
     }
     
-    func callInviteCancelled(_ callInvite: TVOCallInvite?) {
-        NSLog("callInviteCancelled:")
+    func callInviteCanceled(_ callInvite: TVOCallInvite?) {
+        NSLog("callInviteCanceled:")
         
         if (callInvite?.callSid != self.callInvite?.callSid) {
-            NSLog("Incoming (but not current) call invite from \(callInvite?.from) cancelled. Just ignore it.");
+            NSLog("Incoming (but not current) call invite from \(callInvite?.from) canceled. Just ignore it.");
             return;
         }
         
@@ -276,7 +276,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         toggleUIState(isEnabled: true)
     }
     
-    func call(_ call: TVOCall, didFailWithError error: Error) {
+    func call(_ call: TVOCall?, didFailWithError error: Error) {
         NSLog("call:didFailWithError: \(error.localizedDescription)");
         
         self.call = nil


### PR DESCRIPTION
The `TVOCall` object for the first parameter of the `call:didFailWithError:` method was changed to optional last time, but missed to update the one in regular quickstart. CallKit one was updated last time.