### PR TITLE
Updates for Voice 2.0.0-beta17 release

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'SwiftVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '2.0.0-beta16'
+  pod 'TwilioVoice', '2.0.0-beta17'
   use_frameworks!
 
   target 'SwiftVoiceQuickstart' do

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -157,6 +157,14 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
 
     // MARK: TVONotificaitonDelegate
     func callInviteReceived(_ callInvite: TVOCallInvite) {
+        if (callInvite.state == .pending) {
+            handleCallInviteReceived(callInvite)
+        } else if (callInvite.state == .canceled) {
+            handleCallInviteCanceled(callInvite)
+        }
+    }
+    
+    func handleCallInviteReceived(_ callInvite: TVOCallInvite) {
         NSLog("callInviteReceived:")
         
         if (self.callInvite != nil && self.callInvite?.state == .pending) {
@@ -174,12 +182,10 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         reportIncomingCall(from: "Voice Bot", uuid: callInvite.uuid)
     }
     
-    func callInviteCanceled(_ callInvite: TVOCallInvite?) {
+    func handleCallInviteCanceled(_ callInvite: TVOCallInvite) {
         NSLog("callInviteCanceled:")
         
-        if let callInvite = callInvite {
-            performEndCallAction(uuid: callInvite.uuid)
-        }
+        performEndCallAction(uuid: callInvite.uuid)
 
         self.callInvite = nil
     }
@@ -258,7 +264,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
                        options: options,
                        animations: { [weak iconView] in
             if let iconView = iconView {
-                iconView.transform = iconView.transform.rotated(by: CGFloat(M_PI/2))
+                iconView.transform = iconView.transform.rotated(by: CGFloat(Double.pi/2))
             }
         }) { [weak self] (finished: Bool) in
             guard let strongSelf = self else {

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -151,6 +151,14 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
 
     // MARK: TVONotificaitonDelegate
     func callInviteReceived(_ callInvite: TVOCallInvite) {
+        if (callInvite.state == .pending) {
+            handleCallInviteReceived(callInvite)
+        } else if (callInvite.state == .canceled) {
+            handleCallInviteCanceled(callInvite)
+        }
+    }
+    
+    func handleCallInviteReceived(_ callInvite: TVOCallInvite) {
         NSLog("callInviteReceived:")
         
         if (self.callInvite != nil && self.callInvite?.state == .pending) {
@@ -221,11 +229,11 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         }
     }
     
-    func callInviteCanceled(_ callInvite: TVOCallInvite?) {
+    func handleCallInviteCanceled(_ callInvite: TVOCallInvite) {
         NSLog("callInviteCanceled:")
         
-        if (callInvite?.callSid != self.callInvite?.callSid) {
-            NSLog("Incoming (but not current) call invite from \(callInvite?.from) canceled. Just ignore it.");
+        if (callInvite.callSid != self.callInvite?.callSid) {
+            NSLog("Incoming (but not current) call invite from \(callInvite.from) canceled. Just ignore it.");
             return;
         }
         
@@ -395,7 +403,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
                        options: options,
                        animations: { [weak iconView] in
             if let iconView = iconView {
-                iconView.transform = iconView.transform.rotated(by: CGFloat(M_PI/2))
+                iconView.transform = iconView.transform.rotated(by: CGFloat(Double.pi/2))
             }
         }) { [weak self] (finished: Bool) in
             guard let strongSelf = self else {


### PR DESCRIPTION
- Podspec version bumped
- The `callInviteReceived:` method is now called for both `TVOCallInviteStatePending` and `TVOCallInviteStateCanceled` states and the original `callInviteCanceled:` method is removed from the `TVONotificationDelegate` protocol