### PR TITLE
Update for Voice 2.0.0-beta21

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'SwiftVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '2.0.0-beta20'
+  pod 'TwilioVoice', '2.0.0-beta21'
   use_frameworks!
 
   target 'SwiftVoiceQuickstart' do

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -216,11 +216,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         if let completion = self.callKitCompletionCallback {
             completion(false)
         }
-        
-        /**
-         * 1. performVoiceCall mutates call.uuid by setting it to a non-null value.
-         * 2. performOutgoingVoiceCall produces a call with a valid UUID.
-         */
+
         performEndCallAction(uuid: call.uuid)
         callDisconnected()
     }
@@ -232,10 +228,6 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             NSLog("Call disconnected")
         }
         
-        /**
-         * 1. performVoiceCall mutates call.uuid by setting it to a non-null value.
-         * 2. performOutgoingVoiceCall produces a call with a valid UUID.
-         */
         performEndCallAction(uuid: call.uuid)
         callDisconnected()
     }
@@ -349,6 +341,8 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         //      `provider:performAnswerCallAction:` per the WWDC examples.
         // TwilioVoice.configureAudioSession()
         
+        assert(action.callUUID == self.callInvite?.uuid)
+        
         self.performAnswerVoiceCall(uuid: action.callUUID) { (success) in
             if (success) {
                 action.fulfill()
@@ -372,6 +366,16 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
 
         action.fulfill()
     }
+    
+    func provider(_ provider: CXProvider, perform action: CXSetHeldCallAction) {
+        NSLog("provider:performSetHeldAction:")
+        if (self.call?.state == .connected) {
+            self.call?.isOnHold = action.isOnHold
+            action.fulfill()
+        } else {
+            action.fail()
+        }
+    }
 
     // MARK: Call Kit Actions
     func performStartCallAction(uuid: UUID, handle: String) {
@@ -390,7 +394,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             let callUpdate = CXCallUpdate()
             callUpdate.remoteHandle = callHandle
             callUpdate.supportsDTMF = true
-            callUpdate.supportsHolding = false
+            callUpdate.supportsHolding = true
             callUpdate.supportsGrouping = false
             callUpdate.supportsUngrouping = false
             callUpdate.hasVideo = false
@@ -405,7 +409,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         let callUpdate = CXCallUpdate()
         callUpdate.remoteHandle = callHandle
         callUpdate.supportsDTMF = true
-        callUpdate.supportsHolding = false
+        callUpdate.supportsHolding = true
         callUpdate.supportsGrouping = false
         callUpdate.supportsUngrouping = false
         callUpdate.hasVideo = false

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -221,7 +221,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
          * 1. performVoiceCall mutates call.uuid by setting it to a non-null value.
          * 2. performOutgoingVoiceCall produces a call with a valid UUID.
          */
-        performEndCallAction(uuid: call.uuid!)
+        performEndCallAction(uuid: call.uuid)
         callDisconnected()
     }
     
@@ -236,7 +236,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
          * 1. performVoiceCall mutates call.uuid by setting it to a non-null value.
          * 2. performOutgoingVoiceCall produces a call with a valid UUID.
          */
-        performEndCallAction(uuid: call.uuid!)
+        performEndCallAction(uuid: call.uuid)
         callDisconnected()
     }
     
@@ -444,27 +444,12 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             return
         }
         
-        call = TwilioVoice.call(accessToken, params: [:], delegate: self)
-        
-        guard let call = call else {
-            NSLog("Failed to start outgoing call")
-            completionHandler(false)
-            return
-        }
-        
-        call.uuid = uuid
-        
+        call = TwilioVoice.call(accessToken, params: [:], uuid:uuid, delegate: self)
         self.callKitCompletionCallback = completionHandler
     }
     
     func performAnswerVoiceCall(uuid: UUID, completionHandler: @escaping (Bool) -> Swift.Void) {
-        guard let call = self.callInvite?.accept(with: self) else {
-            completionHandler(false)
-            return
-        }
-        
-        call.uuid = uuid
-        
+        call = self.callInvite?.accept(with: self)
         self.callInvite = nil
         self.callKitCompletionCallback = completionHandler
     }

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -77,14 +77,8 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             playOutgoingRingtone(completion: { [weak self] in
                 if let strongSelf = self {
                     strongSelf.call = TwilioVoice.call(accessToken, params: [:], delegate: strongSelf)
-                    
-                    if (strongSelf.call == nil) {
-                        NSLog("Failed to start outgoing call")
-                        return
-                    } else {
-                        strongSelf.toggleUIState(isEnabled: false)
-                        strongSelf.startSpin()
-                    }
+                    strongSelf.toggleUIState(isEnabled: false)
+                    strongSelf.startSpin()
                 }
             })
         }


### PR DESCRIPTION
- Update Podfile version
- Return value of `TwilioVoice.call()` and `TVOCallInvite.accept()` are now `nonnull` in beta21.
- In the CallKit sample, use `TwilioVoice.call:params:uuid:delegate:` to provide proper UUID from the action. Also implemented the `provider:performSetHeldCallAction:` method to demo the newly added set-hold function of `TVOCall`.