### PR TITLE
New PushKit delegate method for iOS 11

### DIFF
--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -193,7 +193,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     }
 
     /**
-     * This is delegate method is available on iOS 11 and above. Call the completion handler once the
+     * This delegate method is available on iOS 11 and above. Call the completion handler once the
      * notification payload is passed to the `TwilioVoice.handleNotification()` method.
      */
     func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType, completion: @escaping () -> Void) {

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -180,6 +180,10 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         self.deviceTokenString = nil
     }
 
+    /**
+     * Try using the `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` method if
+     * your application is targeting iOS 11. This delegate method wil soon be deprecated by Apple.
+     */
     func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, forType type: PKPushType) {
         NSLog("pushRegistry:didReceiveIncomingPushWithPayload:forType:")
 
@@ -188,6 +192,19 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         }
     }
 
+    /**
+     * This is delegate method is available in iOS 11 and above. Call the completion handler once the
+     * notification payload is passed to the `TwilioVoice.handleNotification()` method.
+     */
+    func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType, completion: @escaping () -> Void) {
+        NSLog("pushRegistry:didReceiveIncomingPushWithPayload:forType:completion:")
+        
+        if (type == PKPushType.voIP) {
+            TwilioVoice.handleNotification(payload.dictionaryPayload, delegate: self)
+        }
+        
+        completion()
+    }
 
     // MARK: TVONotificaitonDelegate
     func callInviteReceived(_ callInvite: TVOCallInvite) {

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -182,7 +182,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
 
     /**
      * Try using the `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` method if
-     * your application is targeting iOS 11. This delegate method wil soon be deprecated by Apple.
+     * your application is targeting iOS 11. According to the docs, this delegate method is deprecated by Apple.
      */
     func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, forType type: PKPushType) {
         NSLog("pushRegistry:didReceiveIncomingPushWithPayload:forType:")
@@ -193,7 +193,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     }
 
     /**
-     * This is delegate method is available in iOS 11 and above. Call the completion handler once the
+     * This is delegate method is available on iOS 11 and above. Call the completion handler once the
      * notification payload is passed to the `TwilioVoice.handleNotification()` method.
      */
     func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType, completion: @escaping () -> Void) {

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -168,8 +168,8 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     }
 
     /**
-     * This is delegate method is available in iOS 11 and above. Call the completion handler once the
-     * notification payload is passed to the `TwilioVoice.handleNotification()` method.
+     * Try using the `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` method if
+     * your application is targeting iOS 11. According to the docs, this delegate method is deprecated by Apple.
      */
     func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, forType type: PKPushType) {
         NSLog("pushRegistry:didReceiveIncomingPushWithPayload:forType:")

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -167,6 +167,10 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         self.deviceTokenString = nil
     }
 
+    /**
+     * This is delegate method is available in iOS 11 and above. Call the completion handler once the
+     * notification payload is passed to the `TwilioVoice.handleNotification()` method.
+     */
     func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, forType type: PKPushType) {
         NSLog("pushRegistry:didReceiveIncomingPushWithPayload:forType:")
 
@@ -174,7 +178,20 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             TwilioVoice.handleNotification(payload.dictionaryPayload, delegate: self)
         }
     }
-
+    
+    /**
+     * This is delegate method is available in iOS 11 and above. Call the completion handler once the
+     * notification payload is passed to the `TwilioVoice.handleNotification()` method.
+     */
+    func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType, completion: @escaping () -> Void) {
+        NSLog("pushRegistry:didReceiveIncomingPushWithPayload:forType:completion:")
+        
+        if (type == PKPushType.voIP) {
+            TwilioVoice.handleNotification(payload.dictionaryPayload, delegate: self)
+        }
+        
+        completion()
+    }
 
     // MARK: TVONotificaitonDelegate
     func callInviteReceived(_ callInvite: TVOCallInvite) {

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -180,7 +180,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     }
     
     /**
-     * This is delegate method is available in iOS 11 and above. Call the completion handler once the
+     * This delegate method is available in iOS 11 and above. Call the completion handler once the
      * notification payload is passed to the `TwilioVoice.handleNotification()` method.
      */
     func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType, completion: @escaping () -> Void) {


### PR DESCRIPTION
The `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` is available on iOS 11 and above. The original `pushRegistry:didReceiveIncomingPushWithPayload:forType:` [will soon be deprecated by Apple](https://developer.apple.com/documentation/pushkit/pkpushregistrydelegate/1614492-pushregistry?language=swift).

The `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` method will be called if both the methods exist.

Note: calling the `TwilioVoice.handleNotification()` method is guaranteed to get at least one of the `TVONotificationDelegate` callback immediately, so it is safe to call the completion handler right after calling `TwilioVoice.handleNotification()`.