### PR TITLE
Update for Voice 3.0.0-preview1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,11 +3,11 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'SwiftVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '~> 2.0.0'
+  pod 'TwilioVoice', '3.0.0-preview1'
   use_frameworks!
 
   target 'SwiftVoiceQuickstart' do
-    platform :ios, '8.1'
+    platform :ios, '10.0'
     project 'SwiftVoiceQuickstart.xcproject'
   end
   

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Twilio Voice Swift Quickstart for iOS
 
-> **Deprecation Notice - Versions 2.0.0-beta9 to 2.0.0-beta12**
->
-> Please note that **versions 2.0.0-beta9 to 2.0.0-beta12 of the Programmable Voice iOS library are deprecated and will stop working on September 13, 2018**. Please make sure you’re using the latest version of the library in your apps, and make sure your customers update their apps by that date. For more information please review the following knowledge base [article](https://support.twilio.com/hc/en-us/articles/360002897814-Legacy-Twilio-Programmable-Voice-SDKs-impacted-by-SSL-certificate-deprecation).
+> This is a developer preview release of the Programmable Voice 3.X SDK for iOS. This major version now uses WebRTC and is still under active development. APIs are subject to change and we recommend you look at known issues provided in the [changelog](https://www.twilio.com/docs/voice/voip-sdk/ios/changelog).
+> To use a generally available version of the Programmable Voice SDKs for iOS please see the [master](https://github.com/twilio/video-quickstart-swift/tree/master) branch based on the 2.X APIs.
 
 ## Get started with Voice on iOS:
 * [Quickstart](#quickstart) - Run the quickstart app

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ CXTransaction *transaction = [[CXTransaction alloc] initWithAction:setHeldCallAc
 You can find more documentation on getting started as well as our latest AppleDoc below:
 
 * [Getting Started](https://www.twilio.com/docs/api/voice-sdk/ios/getting-started)
-* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/latest/docs)
+* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-preview1/docs)
 
 ## Twilio Helper Libraries
 To learn more about how to use TwiML and the Programmable Voice Calls API, check out our TwiML quickstarts:

--- a/SwiftVoiceCallKitQuickstart/AppDelegate.swift
+++ b/SwiftVoiceCallKitQuickstart/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        NSLog("Twilio Voice Version: %@", TwilioVoice.version())
+        NSLog("Twilio Voice Version: %@", TwilioVoice.sdkVersion())
 
         return true
     }

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -304,15 +304,19 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     // MARK: AVAudioSession
     func toggleAudioRoute(toSpeaker: Bool) {
         // The mode set by the Voice SDK is "VoiceChat" so the default audio route is the built-in receiver. Use port override to switch the route.
-        do {
-            if (toSpeaker) {
-                try AVAudioSession.sharedInstance().overrideOutputAudioPort(.speaker)
-            } else {
-                try AVAudioSession.sharedInstance().overrideOutputAudioPort(.none)
+        audioDevice.block = {
+            kDefaultAVAudioSessionConfigurationBlock()
+            do {
+                if (toSpeaker) {
+                    try AVAudioSession.sharedInstance().overrideOutputAudioPort(.speaker)
+                } else {
+                    try AVAudioSession.sharedInstance().overrideOutputAudioPort(.none)
+                }
+            } catch {
+                NSLog(error.localizedDescription)
             }
-        } catch {
-            NSLog(error.localizedDescription)
         }
+        audioDevice.block()
     }
 
 

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -90,10 +90,10 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
 
     func fetchAccessToken() -> String? {
         let endpointWithIdentity = String(format: "%@?identity=%@", accessTokenEndpoint, identity)
-        guard let accessTokenURL = URL(string: "https://client:chunder@chunder-interactive.appspot.com/accessToken?realm=prod&identity=voiceqs&push_platform=apn_sandbox") else {
+        guard let accessTokenURL = URL(string: baseURLString + endpointWithIdentity) else {
             return nil
         }
-
+        
         return try? String.init(contentsOf: accessTokenURL, encoding: .utf8)
     }
     

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -44,8 +44,6 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     required init?(coder aDecoder: NSCoder) {
         isSpinning = false
         voipRegistry = PKPushRegistry.init(queue: DispatchQueue.main)
-        
-        TwilioVoice.logLevel = .all
 
         let configuration = CXProviderConfiguration(localizedName: "CallKit Quickstart")
         configuration.maximumCallGroups = 1

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -94,7 +94,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         
         return try? String.init(contentsOf: accessTokenURL, encoding: .utf8)
     }
-    
+
     func toggleUIState(isEnabled: Bool, showCallControl: Bool) {
         placeCallButton.isEnabled = isEnabled
         if (showCallControl) {

--- a/SwiftVoiceQuickstart.xcodeproj/project.pbxproj
+++ b/SwiftVoiceQuickstart.xcodeproj/project.pbxproj
@@ -305,7 +305,7 @@
 				CODE_SIGN_ENTITLEMENTS = SwiftVoiceQuickstart/SwiftVoiceQuickstart.entitlements;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SwiftVoiceQuickstart/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.SwiftVoiceQuickstart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -320,7 +320,7 @@
 				CODE_SIGN_ENTITLEMENTS = SwiftVoiceQuickstart/SwiftVoiceQuickstart.entitlements;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SwiftVoiceQuickstart/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.SwiftVoiceQuickstart;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/SwiftVoiceQuickstart/AppDelegate.swift
+++ b/SwiftVoiceQuickstart/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
-        NSLog("Twilio Voice Version: %@", TwilioVoice.version())
+        NSLog("Twilio Voice Version: %@", TwilioVoice.sdkVersion())
         self.configureUserNotifications()
 
         return true

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -46,8 +46,6 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
 
         voipRegistry.delegate = self
         voipRegistry.desiredPushTypes = Set([PKPushType.voIP])
-        
-        TwilioVoice.logLevel = .all
     }
 
     override func viewDidLoad() {

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -47,7 +47,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         voipRegistry.delegate = self
         voipRegistry.desiredPushTypes = Set([PKPushType.voIP])
         
-        TwilioVoice.logLevel = .verbose
+        TwilioVoice.logLevel = .all
     }
 
     override func viewDidLoad() {
@@ -92,7 +92,10 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             
             playOutgoingRingtone(completion: { [weak self] in
                 if let strongSelf = self {
-                    strongSelf.call = TwilioVoice.call(accessToken, params: [twimlParamTo : strongSelf.outgoingValue.text!], delegate: strongSelf)
+                    let connectOptions: TVOConnectOptions = TVOConnectOptions(accessToken: accessToken) { (builder) in
+                        builder.params = [twimlParamTo : strongSelf.outgoingValue.text!]
+                    }
+                    strongSelf.call = TwilioVoice.connect(with: connectOptions, delegate: strongSelf)
                     strongSelf.toggleUIState(isEnabled: false, showCallControl: false)
                     strongSelf.startSpin()
                 }
@@ -251,7 +254,10 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         let acceptAction = UIAlertAction(title: "Accept", style: .default) { [weak self] (action) in
             if let strongSelf = self {
                 strongSelf.stopIncomingRingtone()
-                strongSelf.call = callInvite.accept(with: strongSelf)
+                let acceptOptions: TVOAcceptOptions = TVOAcceptOptions(callInvite: callInvite) { (builder) in
+                    builder.uuid = strongSelf.callInvite?.uuid
+                }
+                strongSelf.call = callInvite.accept(with: acceptOptions, delegate: strongSelf)
                 strongSelf.callInvite = nil
                 
                 strongSelf.incomingAlertController = nil

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -349,15 +349,20 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     // MARK: AVAudioSession
     func toggleAudioRoute(toSpeaker: Bool) {
         // The mode set by the Voice SDK is "VoiceChat" so the default audio route is the built-in receiver. Use port override to switch the route.
-        do {
-            if (toSpeaker) {
-                try AVAudioSession.sharedInstance().overrideOutputAudioPort(.speaker)
-            } else {
-                try AVAudioSession.sharedInstance().overrideOutputAudioPort(.none)
+        let audioDevice: TVODefaultAudioDevice = TwilioVoice.audioDevice as! TVODefaultAudioDevice
+        audioDevice.block = {
+            kDefaultAVAudioSessionConfigurationBlock()
+            do {
+                if (toSpeaker) {
+                    try AVAudioSession.sharedInstance().overrideOutputAudioPort(.speaker)
+                } else {
+                    try AVAudioSession.sharedInstance().overrideOutputAudioPort(.none)
+                }
+            } catch {
+                NSLog(error.localizedDescription)
             }
-        } catch {
-            NSLog(error.localizedDescription)
         }
+        audioDevice.block()
     }
     
     


### PR DESCRIPTION
This pull request is to apply updates to accommodate API changes in Voice SDK 3.0.0-preview1. For more details, checkout the changelog of the [Programmable Voice iOS SDK](https://www.twilio.com/docs/voice/voip-sdk/ios/changelog).

Update for Voice iOS 3.0.0-preview1
- `[TwilioVoice version]` is now `[TwilioVoice sdkVersion]` to avoid method ambiguity with `NSObject`.
- Update log level.
- Use `TwilioVoice.audioDevice` and `TVODefaultAudioDevice` for AVAudioSession configuration and audio start/stop for CallKit integration.
- In `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` callback, fulfill the completion in the main queue to ensure the incoming call can be reported to CallKit and show the system call UI if the app was previously terminated.
- Use new connect/accept methods for connecting calls.