### PR TITLE
Dispatch the completion callback to the main queue

### DIFF
--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -203,7 +203,9 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             TwilioVoice.handleNotification(payload.dictionaryPayload, delegate: self)
         }
         
-        completion()
+        DispatchQueue.main.async {
+            completion()
+        }
     }
 
     // MARK: TVONotificaitonDelegate

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -190,7 +190,9 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             TwilioVoice.handleNotification(payload.dictionaryPayload, delegate: self)
         }
         
-        completion()
+        DispatchQueue.main.async {
+            completion()
+        }
     }
 
     // MARK: TVONotificaitonDelegate


### PR DESCRIPTION
To ensure good background experience, especially when the app was terminated, dispatch the didReceiveIncomingPush completion to the main queue so that the (CallKit) can be properly shown.