### PR TITLE
Updates for 3.0.0-preview3

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'SwiftVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '3.0.0-preview2'
+  pod 'TwilioVoice', '3.0.0-preview3'
   use_frameworks!
 
   target 'SwiftVoiceQuickstart' do

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ CXTransaction *transaction = [[CXTransaction alloc] initWithAction:setHeldCallAc
 You can find more documentation on getting started as well as our latest AppleDoc below:
 
 * [Getting Started](https://www.twilio.com/docs/api/voice-sdk/ios/getting-started)
-* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-preview2/docs)
+* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-preview3/docs)
 
 ## Twilio Helper Libraries
 To learn more about how to use TwiML and the Programmable Voice Calls API, check out our TwiML quickstarts:

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -216,19 +216,10 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
 
     // MARK: TVONotificaitonDelegate
     func callInviteReceived(_ callInvite: TVOCallInvite) {
-        handleCallInviteReceived(callInvite)
-    }
-
-    func cancelledCallInviteReceived(_ cancelledCallInvite: TVOCancelledCallInvite) {
-        handleCallInviteCancelled(cancelledCallInvite)
-    }
-    
-    func handleCallInviteReceived(_ callInvite: TVOCallInvite) {
         NSLog("callInviteReceived:")
         
         if (self.callInvite != nil) {
-            NSLog("Already a pending incoming call invite.");
-            NSLog("  >> Ignoring call from %@", callInvite.from);
+            NSLog("A callInvite is already in progress. Ignoring the incoming call invite from \(callInvite.from)")
             return;
         } else if (self.call != nil) {
             NSLog("Already an active call.");
@@ -241,7 +232,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         reportIncomingCall(from: "Voice Bot", uuid: callInvite.uuid)
     }
     
-    func handleCallInviteCancelled(_ cancelledCallInvite: TVOCancelledCallInvite) {
+    func cancelledCallInviteReceived(_ cancelledCallInvite: TVOCancelledCallInvite) {
         NSLog("callInviteCanceled:")
         
         if (self.callInvite == nil ||

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -219,7 +219,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         NSLog("callInviteReceived:")
         
         if (self.callInvite != nil) {
-            NSLog("A callInvite is already in progress. Ignoring the incoming call invite from \(callInvite.from)")
+            NSLog("A CallInvite is already in progress. Ignoring the incoming CallInvite from \(callInvite.from)")
             return;
         } else if (self.call != nil) {
             NSLog("Already an active call.");
@@ -233,11 +233,11 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     }
     
     func cancelledCallInviteReceived(_ cancelledCallInvite: TVOCancelledCallInvite) {
-        NSLog("callInviteCanceled:")
+        NSLog("cancelledCallInviteCanceled:")
         
         if (self.callInvite == nil ||
             self.callInvite!.callSid != cancelledCallInvite.callSid) {
-            NSLog("No matching pending Call Invite. Ignoring the Cancelled Call Invite")
+            NSLog("No matching pending CallInvite. Ignoring the Cancelled CallInvite")
             return
         }
         

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -199,10 +199,10 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         NSLog("callInviteReceived:")
         
         if (self.callInvite != nil) {
-            NSLog("A callInvite is already in progress. Ignoring the incoming call invite from \(callInvite.from)")
+            NSLog("A CallInvite is already in progress. Ignoring the incoming CallInvite from \(callInvite.from)")
             return
         } else if (self.call != nil && self.call?.state == .connected) {
-            NSLog("Already an active call. Ignoring incoming call invite from \(callInvite.from)");
+            NSLog("Already an active call. Ignoring incoming CallInvite from \(callInvite.from)");
             return;
         }
         
@@ -231,7 +231,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         
         let ignoreAction = UIAlertAction(title: "Ignore", style: .default) { [weak self] (action) in
             if let strongSelf = self {
-                /* To ignore the call invite, you don't have to do anything but just literally ignore it */
+                /* To ignore the CallInvite, you don't have to do anything but just literally ignore it */
                 
                 strongSelf.callInvite = nil
                 strongSelf.stopIncomingRingtone()
@@ -270,11 +270,11 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     }
     
     func cancelledCallInviteReceived(_ cancelledCallInvite: TVOCancelledCallInvite) {
-        NSLog("callInviteCanceled:")
+        NSLog("cancelledCallInviteCanceled:")
         
         if (self.callInvite == nil ||
             self.callInvite!.callSid != cancelledCallInvite.callSid) {
-            NSLog("No matching pending Call Invite. Ignoring the Cancelled Call Invite")
+            NSLog("No matching pending CallInvite. Ignoring the Cancelled CallInvite")
             return
         }
         

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -196,17 +196,17 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
 
     // MARK: TVONotificaitonDelegate
     func callInviteReceived(_ callInvite: TVOCallInvite) {
-        if (callInvite.state == .pending) {
-            handleCallInviteReceived(callInvite)
-        } else if (callInvite.state == .canceled) {
-            handleCallInviteCanceled(callInvite)
-        }
+        handleCallInviteReceived(callInvite)
+    }
+
+    func cancelledCallInviteReceived(_ cancelledCallInvite: TVOCancelledCallInvite) {
+        handleCallInviteCancelled(cancelledCallInvite)
     }
     
     func handleCallInviteReceived(_ callInvite: TVOCallInvite) {
         NSLog("callInviteReceived:")
         
-        if (self.callInvite != nil && self.callInvite?.state == .pending) {
+        if (self.callInvite != nil) {
             NSLog("Already a pending call invite. Ignoring incoming call invite from \(callInvite.from)")
             return
         } else if (self.call != nil && self.call?.state == .connected) {
@@ -277,12 +277,13 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         }
     }
     
-    func handleCallInviteCanceled(_ callInvite: TVOCallInvite) {
+    func handleCallInviteCancelled(_ cancelledCallInvite: TVOCancelledCallInvite) {
         NSLog("callInviteCanceled:")
         
-        if (callInvite.callSid != self.callInvite?.callSid) {
-            NSLog("Incoming (but not current) call invite from \(callInvite.from) canceled. Just ignore it.");
-            return;
+        if (self.callInvite == nil ||
+            self.callInvite!.callSid != cancelledCallInvite.callSid) {
+            NSLog("No matching pending Call Invite. Ignoring the Cancelled Call Invite")
+            return
         }
         
         self.stopIncomingRingtone()
@@ -301,12 +302,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         
         UIApplication.shared.cancelAllLocalNotifications()
     }
-    
-    func notificationError(_ error: Error) {
-        NSLog("notificationError: \(error.localizedDescription)")
-    }
-    
-    
+
     // MARK: TVOCallDelegate
     func callDidConnect(_ call: TVOCall) {
         NSLog("callDidConnect:")

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -196,18 +196,10 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
 
     // MARK: TVONotificaitonDelegate
     func callInviteReceived(_ callInvite: TVOCallInvite) {
-        handleCallInviteReceived(callInvite)
-    }
-
-    func cancelledCallInviteReceived(_ cancelledCallInvite: TVOCancelledCallInvite) {
-        handleCallInviteCancelled(cancelledCallInvite)
-    }
-    
-    func handleCallInviteReceived(_ callInvite: TVOCallInvite) {
         NSLog("callInviteReceived:")
         
         if (self.callInvite != nil) {
-            NSLog("Already a pending call invite. Ignoring incoming call invite from \(callInvite.from)")
+            NSLog("A callInvite is already in progress. Ignoring the incoming call invite from \(callInvite.from)")
             return
         } else if (self.call != nil && self.call?.state == .connected) {
             NSLog("Already an active call. Ignoring incoming call invite from \(callInvite.from)");
@@ -277,7 +269,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         }
     }
     
-    func handleCallInviteCancelled(_ cancelledCallInvite: TVOCancelledCallInvite) {
+    func cancelledCallInviteReceived(_ cancelledCallInvite: TVOCancelledCallInvite) {
         NSLog("callInviteCanceled:")
         
         if (self.callInvite == nil ||


### PR DESCRIPTION
- Use `3.0.0-preview3` in `Podfile`.
- Adopt the new `TVOCallInvite` and `TVOCancelledCallInvite` object model.
  - `TVOCallInviteState` is removed and the new `TVOCancelledCallInvite` object is introduced.
- Adopt the new `TVONotificationDelegate`
  - `notificationError:` has been removed in `3.0.0-preview3`.
  - `cancelledCallInviteReceived:` method added for `TVOCancelledCallInvite`.