### PR TITLE
Using 3.0.0-beta1

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "twilio/twilio-voice-ios" "3.0.0-preview5"
+github "twilio/twilio-voice-ios" "3.0.0-beta1"

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'SwiftVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '3.0.0-preview5'
+  pod 'TwilioVoice', '3.0.0-beta1'
   use_frameworks!
 
   target 'SwiftVoiceQuickstart' do

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Twilio Voice Swift Quickstart for iOS
 
-> This is a beta release of the Programmable Voice 3.X SDK for iOS. This major version now uses WebRTC and is still under active development. APIs are subject to change and we recommend you look at known issues provided in the [changelog](https://www.twilio.com/docs/voice/voip-sdk/ios/3x-changelog).
+> This is a beta release of the Programmable Voice 3.X SDK for Android. This major version now uses WebRTC. APIs are unlikely to change. We recommend you look at known issues provided in the [changelog](https://www.twilio.com/docs/voice/voip-sdk/ios/3x-changelog).
 > To use a generally available version of the Programmable Voice SDKs for iOS please see the [master](https://github.com/twilio/video-quickstart-swift/tree/master) branch based on the 2.X APIs.
 
 ## Get started with Voice on iOS:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Twilio Voice Swift Quickstart for iOS
 
-> This is a beta release of the Programmable Voice 3.X SDK for Android. This major version now uses WebRTC. APIs are unlikely to change. We recommend you look at known issues provided in the [changelog](https://www.twilio.com/docs/voice/voip-sdk/ios/3x-changelog).
+> This is a beta release of the Programmable Voice 3.X SDK for iOS. This major version now uses WebRTC. APIs are unlikely to change. We recommend you look at known issues provided in the [changelog](https://www.twilio.com/docs/voice/voip-sdk/ios/3x-changelog).
 > To use a generally available version of the Programmable Voice SDKs for iOS please see the [master](https://github.com/twilio/video-quickstart-swift/tree/master) branch based on the 2.X APIs.
 
 ## Get started with Voice on iOS:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Twilio Voice Swift Quickstart for iOS
 
-> This is a developer preview release of the Programmable Voice 3.X SDK for iOS. This major version now uses WebRTC and is still under active development. APIs are subject to change and we recommend you look at known issues provided in the [changelog](https://www.twilio.com/docs/voice/voip-sdk/ios/3x-changelog).
+> This is a beta release of the Programmable Voice 3.X SDK for iOS. This major version now uses WebRTC and is still under active development. APIs are subject to change and we recommend you look at known issues provided in the [changelog](https://www.twilio.com/docs/voice/voip-sdk/ios/3x-changelog).
 > To use a generally available version of the Programmable Voice SDKs for iOS please see the [master](https://github.com/twilio/video-quickstart-swift/tree/master) branch based on the 2.X APIs.
 
 ## Get started with Voice on iOS:
@@ -575,7 +575,7 @@ CXTransaction *transaction = [[CXTransaction alloc] initWithAction:setHeldCallAc
 You can find more documentation on getting started as well as our latest AppleDoc below:
 
 * [Getting Started](https://www.twilio.com/docs/api/voice-sdk/ios/getting-started)
-* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-preview5/docs)
+* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta1/docs)
 
 ## Twilio Helper Libraries
 To learn more about how to use TwiML and the Programmable Voice Calls API, check out our TwiML quickstarts:


### PR DESCRIPTION
https://www.twilio.com/docs/voice/voip-sdk/ios/3x-changelog#300-beta1-november-26-2018

### 3.0.0-beta1

* Programmable Voice iOS SDK 3.0.0-beta1 [[Carthage]](https://www.twilio.com/docs/voice/voip-sdk/ios#carthage), [[Cocoapods]](https://www.twilio.com/docs/voice/voip-sdk/ios#cocoapods), [[Dynamic Framework]](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta1/twilio-voice-ios-3.0.0-beta1.tar.bz2), [[Static Library]](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta1/twilio-voice-ios-static-3.0.0-beta1.tar.bz2), [[docs]](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta1/docs/).

Enhancements

- Added media and signaling related error codes.

Known Issues

- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `TVOConnectOptions` or `TVOAcceptOptions`. ICE servers can be obtained from Twilio's [Network Traversal Service](https://www.twilio.com/stun-turn).
- CLIENT-5258 The SDK size is significantly larger than 2.x. A reduced size will be introduced during the beta period.
- CLIENT-4998 Network handoff, and subsequent connection renegotiation is not supported.
- CLIENT-2985 IPv6 is not supported.
- CLIENT-4547 Insights is not published.
- CLIENT-4537 PCMU is the only supported codec. We plan on adding support for Opus moving forward. [#117](https://github.com/twilio/voice-quickstart-objc/issues/117)
- CLIENT-5398 Unmuting a call on hold causes audio to flow.