### PR TITLE
Add userInitiatedDisconnect flag to properly end CallKit calls

### DIFF
--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -26,19 +26,20 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     @IBOutlet weak var muteSwitch: UISwitch!
     @IBOutlet weak var speakerSwitch: UISwitch!
     
-    var deviceTokenString:String?
+    var deviceTokenString: String?
 
-    var voipRegistry:PKPushRegistry
+    var voipRegistry: PKPushRegistry
 
     var isSpinning: Bool
     var incomingAlertController: UIAlertController?
 
-    var callInvite:TVOCallInvite?
-    var call:TVOCall?
+    var callInvite: TVOCallInvite?
+    var call: TVOCall?
     var callKitCompletionCallback: ((Bool)->Swift.Void?)? = nil
 
-    let callKitProvider:CXProvider
-    let callKitCallController:CXCallController
+    let callKitProvider: CXProvider
+    let callKitCallController: CXCallController
+    var userInitiatedDisconnect: Bool = false
 
     required init?(coder aDecoder: NSCoder) {
         isSpinning = false
@@ -102,6 +103,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
 
     @IBAction func placeCall(_ sender: UIButton) {
         if (self.call != nil && self.call?.state == .connected) {
+            self.userInitiatedDisconnect = true
             performEndCallAction(uuid: self.call!.uuid)
             self.toggleUIState(isEnabled: false, showCallControl: false)
         } else {
@@ -279,12 +281,23 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             NSLog("Call disconnected")
         }
 
+        if !self.userInitiatedDisconnect {
+            var reason = CXCallEndedReason.remoteEnded
+
+            if error != nil {
+                reason = .failed
+            }
+
+            self.callKitProvider.reportCall(with: call.uuid, endedAt: Date(), reason: reason)
+        }
+
         callDisconnected()
     }
     
     func callDisconnected() {
         self.call = nil
         self.callKitCompletionCallback = nil
+        self.userInitiatedDisconnect = false
         
         stopSpin()
         toggleUIState(isEnabled: true, showCallControl: false)


### PR DESCRIPTION
Related issue: https://github.com/twilio/voice-quickstart-swift/issues/190
Use a `userInitiatedDisconnect` flag to properly report the end of a call to CallKit.