### PR TITLE
Update for 3.0.0-beta4 release

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "twilio/twilio-voice-ios" "3.0.0-beta3"
+github "twilio/twilio-voice-ios" "3.0.0-beta4"

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'SwiftVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '3.0.0-beta3'
+  pod 'TwilioVoice', '3.0.0-beta4'
   use_frameworks!
 
   target 'SwiftVoiceQuickstart' do

--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ Please ensure that after deleting the Push Credential you remove or replace the 
 You can find more documentation on getting started as well as our latest AppleDoc below:
 
 * [Getting Started](https://www.twilio.com/docs/api/voice-sdk/ios/getting-started)
-* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta3/docs)
+* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta4/docs)
 
 ## Twilio Helper Libraries
 To learn more about how to use TwiML and the Programmable Voice Calls API, check out our TwiML quickstarts:


### PR DESCRIPTION
### 3.0.0-beta4 (February 14, 2019)

* Programmable Voice iOS SDK 3.0.0-beta4 [[Carthage]](https://www.twilio.com/docs/voice/voip-sdk/ios#carthage), [[Cocoapods]](https://www.twilio.com/docs/voice/voip-sdk/ios#cocoapods), [[Dynamic Framework]](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta4/twilio-voice-ios-3.0.0-beta4.tar.bz2), [[Static Library]](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta4/twilio-voice-ios-static-3.0.0-beta4.tar.bz2), [[docs]](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta4/docs/).

Enhancements
- API Changes
  - `TVOCallFeedbackScoreNoScore` is replaced with `TVOCallFeedbackScoreNotReported`.

Known Issues

- CLIENT-5576 LTE -> WiFi may cause one way audio.
- CLIENT-5578 WiFi to WiFi handover may disconnect the Call.
- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `TVOConnectOptions` or `TVOAcceptOptions`. ICE servers can be obtained from Twilio's [Network Traversal Service](https://www.twilio.com/stun-turn).
- CLIENT-4805 The SDK size is significantly larger than 2.x. A reduced size will be introduced during the beta period.