### PR TITLE
Use Voice iOS 3.0.0-beta8

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "twilio/twilio-voice-ios" "3.0.0-beta7"
+github "twilio/twilio-voice-ios" "3.0.0-beta8"

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'SwiftVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '3.0.0-beta7'
+  pod 'TwilioVoice', '3.0.0-beta8'
   use_frameworks!
 
   target 'SwiftVoiceQuickstart' do

--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ Please ensure that after deleting the Push Credential you remove or replace the 
 You can find more documentation on getting started as well as our latest AppleDoc below:
 
 * [Getting Started](https://www.twilio.com/docs/api/voice-sdk/ios/getting-started)
-* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta7/docs)
+* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta8/docs)
 
 ## Twilio Helper Libraries
 To learn more about how to use TwiML and the Programmable Voice Calls API, check out our TwiML quickstarts:


### PR DESCRIPTION
Bug Fixes

- CLIENT-5796 Fixed an issue where the millisecond timestamp in the Insights event payload overflows on 32-bit architecture devices.
- CLIENT-5830 Removed scripts from `TwilioVoice.framework` that could cause code signing issue when uploading apps to iTunes Connect.

Known Issues

- CLIENT-5576 LTE -> WiFi may cause one way audio.
- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `TVOConnectOptions` or `TVOAcceptOptions`. ICE servers can be obtained from Twilio's [Network Traversal Service](https://www.twilio.com/stun-turn).

Size Report

Architecture | App Download Size | App Storage Size
------------ | --------------- | -----------------
Universal | 5.8 MB | 12.4 MB
arm64 | 2.8 MB | 6.8 MB
armv7 | 3.0 MB | 5.6 MB