### PR TITLE
Use 3.0.0-beta9

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "twilio/twilio-voice-ios" "3.0.0-beta8"
+github "twilio/twilio-voice-ios" "3.0.0-beta9"

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'SwiftVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '3.0.0-beta8'
+  pod 'TwilioVoice', '3.0.0-beta9'
   use_frameworks!
 
   target 'SwiftVoiceQuickstart' do

--- a/README.md
+++ b/README.md
@@ -659,7 +659,7 @@ Please ensure that after deleting the Push Credential you remove or replace the 
 You can find more documentation on getting started as well as our latest AppleDoc below:
 
 * [Getting Started](https://www.twilio.com/docs/api/voice-sdk/ios/getting-started)
-* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta8/docs)
+* [AppleDoc](https://media.twiliocdn.com/sdk/ios/voice/releases/3.0.0-beta9/docs)
 
 ## Twilio Helper Libraries
 To learn more about how to use TwiML and the Programmable Voice Calls API, check out our TwiML quickstarts:


### PR DESCRIPTION
Enhancements

- CLIENT-5806 CLIENT-5807 Updated the API documentation for `[TVOCallInvite acceptWithDelegate:]` and `[TVOCallInvite acceptWithOptions:delegate:]`.
- CLIENT-5810 Updated the API documentation for `TVOCall`.
- API Changes
  - Attempts to connect a Call via `[TwilioVoice connectWithDelegate:]` or `[TVOCallInvite acceptWithDelegate:]` that fail prior to reaching the `TVOCallStateConnected` state will always result in the `call:didFailToConnectWithError:` callback with an error code. However, if `[TVOCall disconnect]` is called while an attempt to connect or accept a call is made, the `call:didDisconnectWithError:` callback will be raised with no error.

Bug Fixes

- CLIENT-5813 Network loss scenarios that resulted in a Call failure now raise the `call:didFailToConnectWithError:` callback. Previously these scenarios erroneously raised `call:didDisconnectWithError:`.
- CLIENT-5754 A Call that fails as a result of not establishing a media connection prior to being connected now raises the `call:didFailToConnectWithError:` callback. Previously this scenario erroneously raised `call:didDisconnectWithError:`.

Known Issues

- CLIENT-5576 LTE -> WiFi may cause one way audio.
- CLIENT-4943 Restrictive networks may fail unless ICE servers are provided via `TVOConnectOptions` or `TVOAcceptOptions`. ICE servers can be obtained from Twilio's [Network Traversal Service](https://www.twilio.com/stun-turn).
- CLIENT-5821 The `packets_lost_fraction` value reported to Insights is incorrectly computed and within the expect range of 0 to 100.
- CLIENT-5835 Events were erroneously reported to Insights when the `TVOConnectOptions.enableInsights` property was set to false.

Sire Report

Architecture | App Download Size | App Storage Size
------------ | --------------- | -----------------
Universal | 5.8 MB | 12.4 MB
arm64 | 2.8 MB | 6.8 MB
armv7 | 3.0 MB | 5.6 MB