### PR TITLE
Update PushKit device token decoding

### DIFF
--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -211,7 +211,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             return
         }
         
-        let deviceToken = (credentials.token as NSData).description
+        let deviceToken = credentials.token.map { String(format: "%02x", $0) }.joined()
 
         TwilioVoice.register(withAccessToken: accessToken, deviceToken: deviceToken) { (error) in
             if let error = error {

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -198,7 +198,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             return
         }
         
-        let deviceToken = (credentials.token as NSData).description
+        let deviceToken = credentials.token.map { String(format: "%02x", $0) }.joined()
 
         TwilioVoice.register(withAccessToken: accessToken, deviceToken: deviceToken) { (error) in
             if let error = error {


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

The iOS SDK that comes with Xcode 11 beta is updating the data structure of the PushKit device token. This PR updates the way of decoding the device token data returned from the `pushRegistry:didUpdatePushCredentials:forType:` callback. The same decoding implementation works for both iOS 13 SDK (Xcode 11) and earlier (Xcode 10 and iOS 12)

Note that with the coming release of iOS 13, using PushKit without CallKit (the `ObjCVoiceQuickstart` project) will cause runtime exception and application crash.