### PR TITLE
Voice iOS 2.1.0 updates

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'SwiftVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '~> 2.0.0'
+  pod 'TwilioVoice', '~> 2.1.0'
   use_frameworks!
 
   target 'SwiftVoiceQuickstart' do

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Twilio Voice Swift Quickstart for iOS
 
-> NOTE: These sample applications use the Twilio Voice 2.x APIs. If you are using SDK 2.x, we highly recommend planning your migration to 3.0 as soon as possible. Support for 2.x will cease 1/1/2020. Until then, SDK 2.x will only receive fixes for critical or security related issues. For examples using our 3.x APIs, please see the [master](https://github.com/twilio/voice-quickstart-swift/tree/master) branch.
+> Note: If you plan to build your apps using Xcode 11 and deploy on iOS 13 devices, please use the `SwiftVoiceCallKitQuickstart` sample app. Reporting new incoming calls to CallKit upon receiving VoIP push notifications is mandated by Apple's new [PushKit push notification policy](https://developer.apple.com/documentation/pushkit/pkpushregistrydelegate/2875784-pushregistry). Failure to integrate the CallKit framework will result in runtime exceptions.
 
 ## Get started with Voice on iOS:
+> NOTE: These sample applications use the Twilio Voice 2.x APIs. If you are using SDK 2.x, we highly recommend planning your migration to 4.0 as soon as possible. Support for 2.x will cease 1/1/2020. Until then, SDK 2.x will only receive fixes for critical or security related issues. For examples using our 3.x APIs, please see the [master](https://github.com/twilio/voice-quickstart-swift/tree/master) branch.
+
 * [Quickstart](#quickstart) - Run the quickstart app
 * [Access Tokens](#access-tokens) - Using access tokens
 * [Managing Audio Interruptions](#managing-audio-interruptions) - Managing audio interruptions

--- a/SwiftVoiceCallKitQuickstart.xcodeproj/project.pbxproj
+++ b/SwiftVoiceCallKitQuickstart.xcodeproj/project.pbxproj
@@ -297,7 +297,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.SwiftVoiceCallKitQuickstart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -312,7 +312,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.SwiftVoiceCallKitQuickstart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -255,10 +255,6 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     
     func notificationError(_ error: Error) {
         NSLog("notificationError: \(error.localizedDescription)")
-        
-        if (self.callInvite != nil) {
-            performEndCallAction(uuid: self.callInvite!.uuid)
-        }
     }
     
     

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -29,7 +29,6 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     var deviceTokenString: String?
 
     var voipRegistry: PKPushRegistry
-    var incomingPushCompletionCallback: (()->Swift.Void?)? = nil
 
     var isSpinning: Bool
     var incomingAlertController: UIAlertController?
@@ -135,18 +134,14 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
 
 
     // MARK: PKPushRegistryDelegate
-    func pushRegistry(_ registry: PKPushRegistry, didUpdate credentials: PKPushCredentials, forType type: PKPushType) {
+    func pushRegistry(_ registry: PKPushRegistry, didUpdate credentials: PKPushCredentials, for type: PKPushType) {
         NSLog("pushRegistry:didUpdatePushCredentials:forType:")
-        
-        if (type != .voIP) {
-            return
-        }
 
         guard let accessToken = fetchAccessToken() else {
             return
         }
         
-        let deviceToken = (credentials.token as NSData).description
+        let deviceToken = credentials.token.map { String(format: "%02x", $0) }.joined()
 
         TwilioVoice.register(withAccessToken: accessToken, deviceToken: deviceToken) { (error) in
             if let error = error {
@@ -160,7 +155,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         self.deviceTokenString = deviceToken
     }
     
-    func pushRegistry(_ registry: PKPushRegistry, didInvalidatePushTokenForType type: PKPushType) {
+    func pushRegistry(_ registry: PKPushRegistry, didInvalidatePushTokenFor type: PKPushType) {
         NSLog("pushRegistry:didInvalidatePushTokenForType:")
         
         if (type != .voIP) {
@@ -187,7 +182,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
      * Try using the `pushRegistry:didReceiveIncomingPushWithPayload:forType:withCompletionHandler:` method if
      * your application is targeting iOS 11. According to the docs, this delegate method is deprecated by Apple.
      */
-    func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, forType type: PKPushType) {
+    func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType) {
         NSLog("pushRegistry:didReceiveIncomingPushWithPayload:forType:")
 
         if (type == PKPushType.voIP) {
@@ -201,19 +196,16 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
      */
     func pushRegistry(_ registry: PKPushRegistry, didReceiveIncomingPushWith payload: PKPushPayload, for type: PKPushType, completion: @escaping () -> Void) {
         NSLog("pushRegistry:didReceiveIncomingPushWithPayload:forType:completion:")
-        // Save for later when the notification is properly handled.
-        self.incomingPushCompletionCallback = completion
 
         if (type == PKPushType.voIP) {
             TwilioVoice.handleNotification(payload.dictionaryPayload, delegate: self)
         }
-    }
-
-    func incomingPushHandled() {
-        if let completion = self.incomingPushCompletionCallback {
-            completion()
-            self.incomingPushCompletionCallback = nil
-        }
+        
+        /**
+         * The Voice SDK processes the call notification and returns the call invite synchronously. Report the incoming call to
+         * CallKit and fulfill the completion before exiting this callback method.
+         */
+        completion()
     }
 
     // MARK: TVONotificaitonDelegate
@@ -231,12 +223,10 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         if (self.callInvite != nil && self.callInvite?.state == .pending) {
             NSLog("Already a pending incoming call invite.");
             NSLog("  >> Ignoring call from %@", callInvite.from);
-            self.incomingPushHandled()
             return;
         } else if (self.call != nil) {
             NSLog("Already an active call.");
             NSLog("  >> Ignoring call from %@", callInvite.from);
-            self.incomingPushHandled()
             return;
         }
         
@@ -251,7 +241,6 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         performEndCallAction(uuid: callInvite.uuid)
 
         self.callInvite = nil
-        self.incomingPushHandled()
     }
     
     func notificationError(_ error: Error) {
@@ -536,6 +525,5 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         call = self.callInvite?.accept(with: self)
         self.callInvite = nil
         self.callKitCompletionCallback = completionHandler
-        self.incomingPushHandled()
     }
 }

--- a/SwiftVoiceCallKitQuickstart/ViewController.swift
+++ b/SwiftVoiceCallKitQuickstart/ViewController.swift
@@ -211,8 +211,18 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     // MARK: TVONotificaitonDelegate
     func callInviteReceived(_ callInvite: TVOCallInvite) {
         if (callInvite.state == .pending) {
+            /**
+             * Calling `[TwilioVoice handleNotification:]` will synchronously process your notification payload and
+             * provide you a `TVOCallInvite` object with `TVOCallInviteStatePending` state.
+             * Report the incoming call to CallKit upon receiving this callback.
+             */
             handleCallInviteReceived(callInvite)
         } else if (callInvite.state == .canceled) {
+            /**
+             * The SDK may call `[TVONotificationDelegate callInviteReceived:]` asynchronously on the main dispatch queue
+             * with a `TVOCallInvite` state of `TVOCallInviteStateCanceled` if the caller hangs up or the client
+             * encounters any other error before the called party could answer or reject the call.
+             */
             handleCallInviteCanceled(callInvite)
         }
     }
@@ -245,6 +255,10 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     
     func notificationError(_ error: Error) {
         NSLog("notificationError: \(error.localizedDescription)")
+        
+        if (self.callInvite != nil) {
+            performEndCallAction(uuid: self.callInvite!.uuid)
+        }
     }
     
     

--- a/SwiftVoiceQuickstart.xcodeproj/project.pbxproj
+++ b/SwiftVoiceQuickstart.xcodeproj/project.pbxproj
@@ -309,7 +309,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.SwiftVoiceQuickstart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -324,7 +324,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.twilio.SwiftVoiceQuickstart;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

- Update Podfile to use Voice iOS 2.1.0
- Update README with migration guide
- Use Swift 4.0 compiler
- Code changes
  - Update device token decoding 
  - Update the mechanism to fulfill the incoming-push completion: now the Voice SDK processes and return a `TVOCallInvite` object synchronously, report the call to CallKit and fulfill the completion before existing the method