### PR TITLE
Removed the quotes from the .env variables. They can be misleading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Download one of the starter projects for the server.
 
 Follow the instructions in the server's README to get the application server up and running locally and accessible via the public Internet. For now just replace the **Twilio Account SID** that you can obtain from the [console](https://www.twilio.com/console), and the `API_KEY` and `API_SECRET` you obtained in the previous step.
     
-    ACCOUNT_SID = 'AC***'
-    API_KEY = 'SK***'
-    API_KEY_SECRET = '***'
+    ACCOUNT_SID=AC12345678901234567890123456789012
+    API_KEY=SK12345678901234567890123456789012
+    API_KEY_SECRET=the_secret_generated_when_creating_the_api_key
 
 ### <a name="bullet4"></a>4. Create a TwiML application
 Next, we need to create a TwiML application. A TwiML application identifies a public URL for retrieving [TwiML call control instructions](https://www.twilio.com/docs/api/twiml). When your iOS app makes a call to the Twilio cloud, Twilio will make a webhook request to this URL, your application server will respond with generated TwiML, and Twilio will execute the instructions you’ve provided.
@@ -98,10 +98,10 @@ Save your TwiML Application configuration, and grab the **TwiML Application SID*
 ### <a name="bullet5"></a>5. Configure your application server
 Let's put the remaining `APP_SID` configuration info into your server code. 
 
-    ACCOUNT_SID = 'AC***'
-    API_KEY = 'SK***'
-    API_KEY_SECRET = '***'
-    APP_SID = 'AP***'
+    ACCOUNT_SID=AC12345678901234567890123456789012
+    API_KEY=SK12345678901234567890123456789012
+    API_KEY_SECRET=the_secret_generated_when_creating_the_api_key
+    APP_SID=AP12345678901234567890123456789012
 
 Once you’ve done that, restart the server so it uses the new configuration info. Now it's time to test.
 
@@ -165,7 +165,7 @@ Once the app is ready for store submission, update the plist with “APS Environ
 
 Now let's go back to your server code and update the Push Credential SID. The Push Credential SID will now be embedded in your access token.
 
-    PUSH_CREDENTIAL_SID = 'CR***'
+    PUSH_CREDENTIAL_SID=CR12345678901234567890123456789012
 
 ### <a name="bullet9"></a>9. Configure Xcode project settings for push notifications
 On the project’s Capabilities tab, enable “**Push Notifications**”.


### PR DESCRIPTION
The quotes can be misleading into including them when setting up the .env variables

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
