### PR TITLE
Update Podfile for referencing the latest 2.1 Voice iOS SDK

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'SwiftVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '~> 2.1.0'
+  pod 'TwilioVoice', '~> 2.1'
   use_frameworks!
 
   target 'SwiftVoiceQuickstart' do


### PR DESCRIPTION
Bug Fixes in Voice iOS 2.1.1

- [CLIENT-6896] Fixed an issue which caused call accept failure. This occurred when the user denied mic access on an incoming call. With this change, mic permissions are no longer requested on an incoming call. They are  requested when the user accepts the call.