### PR TITLE
Make quickstart capable of handling multiple calls or call invites

### DIFF
--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -38,6 +38,8 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     var audioDevice: TVODefaultAudioDevice = TVODefaultAudioDevice()
     var activeCallInvites: [String: TVOCallInvite]! = [:]
     var activeCalls: [String: TVOCall]! = [:]
+    
+    // activeCall represents the last connected call
     var activeCall: TVOCall? = nil
 
     let callKitProvider: CXProvider
@@ -182,6 +184,7 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     }
     
     @IBAction func muteSwitchToggled(_ sender: UISwitch) {
+        // The sample app supports toggling mute from app UI only on the last connected call.
         if let call = self.activeCall {
             call.isMuted = sender.isOn
         }
@@ -391,7 +394,9 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
     }
     
     func callDisconnected(_ call: TVOCall) {
-        self.activeCall = nil
+        if (call == self.activeCall) {
+            self.activeCall = nil
+        }
         self.activeCalls.removeValue(forKey: call.uuid.uuidString)
         
         self.userInitiatedDisconnect = false

--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -36,8 +36,8 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
 
     var callKitCompletionCallback: ((Bool)->Swift.Void?)? = nil
     var audioDevice: TVODefaultAudioDevice = TVODefaultAudioDevice()
-    var activeCallInvites: [TVOCallInvite]? = []
-    var activeCalls: [TVOCall]? = []
+    var activeCallInvites: [TVOCallInvite]! = []
+    var activeCalls: [TVOCall]! = []
 
     let callKitProvider: CXProvider
     let callKitCallController: CXCallController
@@ -108,14 +108,11 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
         }
     }
 
-    @IBAction func placeCall(_ sender: UIButton) {
-        if (!self.activeCalls!.isEmpty) {
-            let call = self.activeCalls![0]
-            if (call.state == .connected) {
-                self.userInitiatedDisconnect = true
-                performEndCallAction(uuid: call.uuid)
-                self.toggleUIState(isEnabled: false, showCallControl: false)
-            }
+    @IBAction func mainButtonPressed(_ sender: Any) {
+        if let call = self.activeCalls.first {
+            self.userInitiatedDisconnect = true
+            performEndCallAction(uuid: call.uuid)
+            self.toggleUIState(isEnabled: false, showCallControl: false)
         } else {
             let uuid = UUID()
             let handle = "Voice Bot"
@@ -635,12 +632,11 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             self.activeCalls?.append(call)
             self.callKitCompletionCallback = completionHandler
             
-            if let version = Float(UIDevice.current.systemVersion), version < 13.0 {
-                self.incomingPushHandled()
-            }
+            self.activeCallInvites = self.activeCallInvites.filter { $0 != callInvite }
             
-            if let index = self.activeCallInvites?.index(of: callInvite) {
-                self.activeCallInvites?.remove(at: index)
+            guard #available(iOS 13, *) else {
+                self.incomingPushHandled()
+                return
             }
         } else {
             NSLog("No CallInvite matches the UUID")


### PR DESCRIPTION
- [x] I acknowledge that all my contributions will be made under the project's license.

### Description
The current sample code assumes that only one call or call invite is is supported at the same time and therefore will not report the VoIP incoming call push notification to CallKit when there is already a pending invite or an active call.

This PR modifies the sample code to be able to handle multiple calls or call invites and ensures that VoIP push notifications are always reported to CallKit as new incoming calls.

### Tested scenarios
This table illustrates how the updated sample app behaves in different call scenarios (all with CallKit integrated):

|     | Scenario | Result |
| --- | -------- | ------ |
| ✅A | Alice calls Bob.<br /> Bob does not accept and let ring.<br />Charlie calls Bob.<br />Bob accepts the call. | Alice and Bob talking.<br />Bob won't see Charlie's incoming call.<br />Charlie was hung up by CallKit when Bob accepted the call. |
| ✅B | Alice calls Bob.<br /> Bob does not accept and let ring.<br />Charlie calls Bob.<br />Bob rejects the call. | Alice was hung up then Charlie's call showed up. |
| ✅C | Alice calls Bob.<br /> Bob accepts the call.<br />Charlie calls Bob.<br />Bob declines Charlie's call. | Charlie was hung up.<br />Alice and Bob continue talking. |
| ✅D | Alice calls Bob.<br /> Bob accepts the call.<br />Charlie calls Bob.<br />Bob "End & Accept" the call. | Alice was hung up.<br />Charlie and Bob talking. |
| ✅E | Bob calls Alice and Alice accepts the call.<br />Charlie calls bob.<br />Bob declines Charlie's call. | Charlie was hung up.<br />Bob and Alice continue talking |
| ✅F | Bob calls Alice and Alice accepts the call.<br />Charlie calls bob.<br />Bob "End & Accept" Charlie's call. | Alice was hung up.<br />Bob and Charlie continue talking |
