### PR TITLE
Use Voice iOS 5.1.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "twilio/twilio-voice-ios" >= 4.3.0
+github "twilio/twilio-voice-ios" >= 5.1.0

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 workspace 'SwiftVoiceQuickstart'
 
 abstract_target 'TwilioVoice' do
-  pod 'TwilioVoice', '~> 5.0'
+  pod 'TwilioVoice', '~> 5.1'
   use_frameworks!
   
   target 'SwiftVoiceQuickstart' do


### PR DESCRIPTION
#### Enhancements

- Incoming call handling improvements. Previously, if we encountered network issues before an incoming call was answered or rejected, we disconnected the call. With this release, we will continue to try and establish a connection to Twilio for a maximum of 40 seconds before we disconnect the call.
- We added support for OpenSSL 1.1.x in the static library version of our SDK. To use this flavor of the SDK, please refer to the instructions included in the [Static Library](https://github.com/twilio/twilio-voice-ios/releases/download/5.1.0/libTwilioVoice.zip)
- We now publish the negotiated codec and its associated parameters to Insights.

| Event Group | Level | Event Name | Description |
|-------------|-------|------------|-------------|
| settings    | INFO  | codec      | Raised when the codec has been selected |

#### Other Improvements

- Improved the way we perform DNS resolution. Previously, some DNS requests could indirectly block the main thread. This is no longer the case.
- `listening-error` event level was incorrectly reported as INFO instead of ERROR to `insights`.

#### Size Impact for 5.1.0

Architecture | App Download Size | App Storage Size
------------ | --------------- | -----------------
Universal | 5.9 MB | 12.6 MB
arm64 | 2.8 MB | 6.8 MB
armv7 | 3.0 MB | 5.6 MB