### PR TITLE
Remove audio device toggling when ending CallKit calls

### DIFF
--- a/SwiftVoiceQuickstart/ViewController.swift
+++ b/SwiftVoiceQuickstart/ViewController.swift
@@ -562,7 +562,6 @@ class ViewController: UIViewController, PKPushRegistryDelegate, TVONotificationD
             NSLog("Unknown UUID to perform end-call action with")
         }
 
-        audioDevice.isEnabled = true
         action.fulfill()
     }
     


### PR DESCRIPTION
### Description ###

The audio-device toggling in the `provider:performEndCallAction:` delegate method would cause the audio engine to print out error messages like these:
```
provider:didDeactivateAudioSession:
[aurioc] AURemoteIO.cpp:1086:Initialize: failed: 561017449 (enable 3, outf< 1 ch,  16000 Hz, Int16> inf< 1 ch,  16000 Hz, Int16>)
[aurioc] AURemoteIO.cpp:1086:Initialize: failed: 561017449 (enable 3, outf< 1 ch,  16000 Hz, Int16> inf< 1 ch,  16000 Hz, Int16>)
[aurioc] AURemoteIO.cpp:1086:Initialize: failed: 561017449 (enable 3, outf< 1 ch,  16000 Hz, Int16> inf< 1 ch,  16000 Hz, Int16>)
[aurioc] AURemoteIO.cpp:1086:Initialize: failed: 561017449 (enable 3, outf< 1 ch,  16000 Hz, Int16> inf< 1 ch,  16000 Hz, Int16>)
[aurioc] AURemoteIO.cpp:1086:Initialize: failed: 561017449 (enable 3, outf< 1 ch,  16000 Hz, Int16> inf< 1 ch,  16000 Hz, Int16>)
```

The audio device only needs to be enabled in the `provider:didActivateAudioSession:` method. Removing the toggling here fixes the error.

### Steps to reproduce ###
- Ongoing (incoming/outgoing) VoIP call using TwilioVoice
- Make a PSTN incoming call to interrupt the existing call
- Tap "End & Accept" in the system call UI