### PR TITLE
Removing iOS 13 Migration Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ## Twilio Voice Quickstart for iOS
 
-> Please see our [iOS 13 Migration Guide](https://github.com/twilio/twilio-voice-ios/blob/Releases/iOS-13-Migration-Guide.md) for the latest information on iOS 13.
-
 ## Get started with Voice on iOS
 * [Quickstart](#quickstart) - Run the swift quickstart app
 * [Examples](#examples) - Sample applications


### PR DESCRIPTION
It's been 4+ years, so probably can take down a prominent link to iOS 13 migration from the top of the README?

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
